### PR TITLE
SystemUI: Use AVCProfileMain for screen recorder

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
+++ b/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
@@ -148,7 +148,7 @@ public class ScreenMediaRecorder extends MediaProjection.Callback {
                 * VIDEO_FRAME_RATE_TO_RESOLUTION_RATIO;
         mMediaRecorder.setVideoEncoder(MediaRecorder.VideoEncoder.H264);
         mMediaRecorder.setVideoEncodingProfileLevel(
-                MediaCodecInfo.CodecProfileLevel.AVCProfileHigh,
+                MediaCodecInfo.CodecProfileLevel.AVCProfileMain,
                 MediaCodecInfo.CodecProfileLevel.AVCLevel3);
         mMediaRecorder.setVideoSize(width, height);
         mMediaRecorder.setVideoFrameRate(refreshRate);


### PR DESCRIPTION
Some devices don't support the High profile very well. Use Main profile, which is more compatible, so they can use screen recorder too.

Change-Id: Iac23480e080edf4300e6f411c3394c0b41030daa